### PR TITLE
docs: make videos same width

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | iOS | Android |
 | --- | --- |
-| <img src="./docs/ios_demo.gif" alt="iOS Demo" height="500"> | <img src="./docs/android_demo.gif" alt="Android Demo" height="500"> |
+| <img src="./docs/ios_demo.gif" alt="iOS Demo" width="300"> | <img src="./docs/android_demo.gif" alt="Android Demo" width="300"> |
 
 
 ## Architecture Overview


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation, Context, Closing issues

Docs to look good

## Proposed Changes
<!--- Describe your changes in detail -->

- change video height to width, so that they're consistent and resize nicely

## Screenshots/Screen Recording:

Before:
<img width="1008" alt="Screenshot 2025-01-23 at 10 16 33" src="https://github.com/user-attachments/assets/6d068641-24d7-4e49-ba7f-de50346e6003" />

After:
<img width="693" alt="Screenshot 2025-01-23 at 10 16 37" src="https://github.com/user-attachments/assets/4da5ed9f-1677-405e-b3fc-7f2b82524e45" />

## Other information


