### PR TITLE
fix: prevent crash in host dev server

### DIFF
--- a/apps/mobile-host/rspack.config.mjs
+++ b/apps/mobile-host/rspack.config.mjs
@@ -211,15 +211,18 @@ export default env => {
       new rspack.IgnorePlugin({
         resourceRegExp: /^@react-native-masked-view/,
       }),
-      // Only register the plugin when RSDOCTOR is true, as the plugin will increase the build time.
-      process.env.RSDOCTOR &&
-        new RsdoctorRspackPlugin({
-          supports: {
-            generateTileGraph: true,
-          },
-        }),
     ],
   };
+
+  if (process.env.RSDOCTOR) {
+    config.plugins.push(
+      new RsdoctorRspackPlugin({
+        supports: {
+          generateTileGraph: true,
+        },
+      }),
+    );
+  }
 
   if (USE_ZEPHYR) {
     return withZephyr()(config);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation, Context, Closing issues

Currently DevServer for host crashes because of a bug in `@module-federation/rspack` (fixed here: https://github.com/module-federation/core/pull/3487). 

This PR creates a workaround so that we avoid the bug in MF altogether (don't use `&&` to short-circuit addition of `RsdoctorPlugin`). 

## Proposed Changes

- use `config.plugins.push` for adding `RsdoctorPlugin`

## Screenshots/Screen Recording:

n/a

## Other information

n/a

