### PR TITLE
fix: update override versions according to GHSA

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "overrides": {
       "esbuild": "^0.25.0",
       "@babel/runtime": "^7.26.10",
-      "@babel/helpers": "^7.26.10"
+      "@babel/helpers": "^7.26.10",
+      "image-size": ">=1.2.1"
     }
   }
 }


### PR DESCRIPTION
I according with GHSA-m5qc-5hw7-8vg7 package JSON updated with fixed versions:

![image2](https://github.com/user-attachments/assets/0fefa1ba-d4c8-4d85-98af-7e92ee039cb2)
